### PR TITLE
Updates the README to to include changes in 1.0.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,10 @@ const App => (
   <>
     <Editor
         autofocus
-        holderId="editorjs-container"
+        holder="editorjs-container"
         excludeDefaultTools={['header']}
-        onChange={(data) => console.log(data)}
+        onChange={() => console.log('Something is changing!!')}
+        onData={(data) => console.log(data)}
         customTools={{
           header: CustomHeader
         }}
@@ -56,9 +57,10 @@ const App => (
 | Name                |    Type    |      Default      | Description                                   |
 | :------------------ | :--------: | :---------------: | :-------------------------------------------- |
 | autofocus           | `boolean`  |      `true`       | Set Caret to the Editor after initialisation  |
-| holderId            |  `string`  | `editorjs-holder` | Id of Element that should contain the Editor  |
+| holder            |  `string`  | `editorjs-holder` | Id of Element that should contain the Editor  |
 | onChange            | `function` |      `null`       | onChange callback                             |
 | onReady             | `function` |      `null`       | onReady callback                              |
+| onData              | `function` |      `null`       | onData callback; used to access data after onChange is called |
 | data                |  `object`  |      `null`       | Previously saved data that should be rendered |
 | customTools         |  `object`  |      `null`       | Set custom tools config or overwrite existed  |
 | excludeDefaultTools |  `array`   |      `null`       | Exclude default tool by tool name             |


### PR DESCRIPTION
## Core

In #16, it's mentioned that `onChange` as of `1.0.3` requires a 0-arity function and notifies when changes are being made. In order to access the sanitized data, `onData` has to be used which requires a 1-arity function. Furthermore, `holderId` was deprecated and `holder` has to be used.

The documentation didn't include the changes to `onChange`, `onData` and `holderId`. This PR changes the README example to include the changes of `onChange`,`onData` and `holderId`.