### PR TITLE
Updates the Props in README to include reinitOnPropsChange

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,13 +57,14 @@ const App => (
 | Name                |    Type    |      Default      | Description                                   |
 | :------------------ | :--------: | :---------------: | :-------------------------------------------- |
 | autofocus           | `boolean`  |      `true`       | Set Caret to the Editor after initialisation  |
-| holder            |  `string`  | `editorjs-holder` | Id of Element that should contain the Editor  |
+| holder              |  `string`  | `editorjs-holder` | Id of Element that should contain the Editor  |
 | onChange            | `function` |      `null`       | onChange callback                             |
 | onReady             | `function` |      `null`       | onReady callback                              |
 | onData              | `function` |      `null`       | onData callback; used to access data after onChange is called |
 | data                |  `object`  |      `null`       | Previously saved data that should be rendered |
 | customTools         |  `object`  |      `null`       | Set custom tools config or overwrite existed  |
 | excludeDefaultTools |  `array`   |      `null`       | Exclude default tool by tool name             |
+| reinitOnPropsChange | `boolean`  |      `false`      | Re initialize the editor if the props change  |
 
 ## Default tools
 


### PR DESCRIPTION
## Core

`reinitOnPropsChange` allows the user to initialize the editor with new props if they wish. This information was missing from the props table.